### PR TITLE
Lower missing trace_entry, trace_exit severity to Info

### DIFF
--- a/src/castep_linter/tests/has_trace_entry_exit.py
+++ b/src/castep_linter/tests/has_trace_entry_exit.py
@@ -84,6 +84,6 @@ def check_trace_entry_exit(node: FortranNode, error_log: ErrorLogger) -> None:
             raise ValueError(err)
 
     if not has_trace_entry:
-        error_log.add_msg("Warning", node, f"Missing trace_entry in {subroutine_name}")
+        error_log.add_msg("Info", node, f"Missing trace_entry in {subroutine_name}")
     if not has_trace_exit:
-        error_log.add_msg("Warning", node, f"Missing trace_exit in {subroutine_name}")
+        error_log.add_msg("Info", node, f"Missing trace_exit in {subroutine_name}")


### PR DESCRIPTION
Because there are many cases in frequently called functions where `trace` is deliberately omitted for performance, this is probably better treated as `Info` rather than `Warning`