### PR TITLE
Add an emacs Flycheck plugin and supporting architecture

### DIFF
--- a/src/castep_linter/error_logging/logger.py
+++ b/src/castep_linter/error_logging/logger.py
@@ -26,13 +26,14 @@ class ErrorLogger:
         err = error_types.new_fortran_error(level, node, message)
         self.errors.append(err)
 
-    def print_errors(self, console: Console, level: str = "Warning") -> None:
+    def print_errors(self, console: Console, level: str = "Warning", *,
+                     print_style: error_types.PrintStyle = error_types.PrintStyle.ANNOTATED) -> None:
         """Print all the contained errors above the level"""
         severity = error_types.ERROR_SEVERITY[level]
 
         for err in self.errors:
             if err.ERROR_SEVERITY >= severity:
-                err.print_err(self.filename, console)
+                err.print_err(self.filename, console, print_style=print_style)
 
     def count_errors(self):
         """Count the number of errors in each category"""

--- a/src/castep_linter/scan_files.py
+++ b/src/castep_linter/scan_files.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from castep_linter import error_logging
 from castep_linter.error_logging.json_writer import write_json
 from castep_linter.error_logging.xml_writer import write_xml
+from castep_linter.error_logging.error_types import PrintStyle
 from castep_linter.fortran import parser
 from castep_linter.tests import CheckFunction, test_list
 
@@ -57,6 +58,11 @@ def parse_args():
         choices=error_logging.ERROR_SEVERITY.keys(),
     )
     arg_parser.add_argument(
+        "-f", "--format", type=lambda x: str(x).upper(),
+        choices=[x.name for x in PrintStyle], help="Format screen printing",
+        default="ANNOTATED"
+    )
+    arg_parser.add_argument(
         "-x", "--xml", type=pathlib.Path, help="File for JUnit xml output if required"
     )
     arg_parser.add_argument(
@@ -102,7 +108,7 @@ def main() -> None:
 
         # Report any errors
         if not args.quiet:
-            error_log.print_errors(console, level=args.level)
+            error_log.print_errors(console, level=args.level, print_style=PrintStyle[args.format])
 
             err_count = error_log.count_errors()
 

--- a/utils/flycheck-castep.el
+++ b/utils/flycheck-castep.el
@@ -1,0 +1,63 @@
+;;; flycheck-castep-linter.el --- Support castep-linter in flycheck
+
+;; Copyright (C) 2024 Jacob Wilkins <jacob.wilkins@stfc.ac.uk>
+;;
+;; Author: Jacob Wilkins <jacob.wilkins@stfc.ac.uk>
+;; Created: 09 Febuary 2024
+;; Version: 1.0
+;; Package-Requires: ((flycheck "0.18"))
+
+;;; Commentary:
+
+;; This package adds support for castep-linter to flycheck.  To use it, add
+;; to your init.el:
+
+;; (require 'flycheck-castep-linter)
+;; (add-hook 'python-mode-hook 'flycheck-mode)
+
+;;; License:
+
+;; This file is not part of GNU Emacs.
+;; However, it is distributed under the same license.
+
+;; GNU Emacs is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+(require 'flycheck)
+
+(flycheck-def-args-var flycheck-castep-linter-args castep-linter)
+
+(flycheck-define-checker castep-linter
+  "castep-linter syntax checker. Requires castep-linter>=0.1.5
+
+Customize `flycheck-castep-linter-args` to add specific args to default
+executable.
+
+See URL `https://pypi.org/project/castep-linter/'."
+
+  :command ("castep-lint" "--format" "GCC"
+            (eval flycheck-castep-linter-args)
+            source-original)
+  :error-patterns
+  ((error line-start (file-name) ":" line ":" column ": Error:" (message) line-end)
+   (warning line-start (file-name) ":" line ":" column ": Warning:" (message) line-end)
+   (info line-start (file-name) ":" line ":" column ": Info:" (message) line-end))
+  :modes f90-mode)
+
+(add-to-list 'flycheck-checkers 'castep-linter t)
+
+(provide 'flycheck-castep)
+;;; flycheck-castep.el ends here


### PR DESCRIPTION
Not sure whether you'd want the flycheck files here (I can open a separate repo), but it may be useful. 

- Add `PrintStyle` enumeration to allow change of printing formats
- Add `GCC` printstyle to provide detail and ease flycheck support 
- Add convenient properties to `FortranMsgBase`